### PR TITLE
Auto-discover the service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,12 @@
   },
   "config": {
     "sort-packages": true
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "MetricLoop\\TransformerMaker\\TransformerMakerServiceProvider"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Added support for Laravel's [package discovery](https://laravel.com/docs/5.7/packages#package-discovery), as I saw discussed in #2.